### PR TITLE
FCGI and SCGI fixes

### DIFF
--- a/boost/cgi/fcgi/acceptor_service_impl.hpp
+++ b/boost/cgi/fcgi/acceptor_service_impl.hpp
@@ -182,8 +182,6 @@ BOOST_CGI_NAMESPACE_BEGIN
        bind(implementation_type& impl, const Endpoint& endpoint
            , boost::system::error_code& ec)
      {
-       acceptor_service_.set_option(impl.acceptor_,
-           boost::asio::socket_base::reuse_address(true), ec);
        return acceptor_service_.bind(impl.acceptor_, endpoint, ec);
      }
 
@@ -201,6 +199,14 @@ BOOST_CGI_NAMESPACE_BEGIN
        listen(implementation_type& impl, int backlog, boost::system::error_code& ec)
      {
        return acceptor_service_.listen(impl.acceptor_, backlog, ec);
+     }
+
+     template<typename SettableSocketOption>
+     boost::system::error_code
+       set_option(implementation_type& impl, const SettableSocketOption& option
+                 , boost::system::error_code& ec)
+     {
+       return acceptor_service_.set_option(impl.acceptor_, option, ec);
      }
      
      void do_accept(implementation_type& impl

--- a/boost/cgi/fcgi/request_acceptor_service.hpp
+++ b/boost/cgi/fcgi/request_acceptor_service.hpp
@@ -137,6 +137,14 @@ BOOST_CGI_NAMESPACE_BEGIN
       return service_impl_.listen(impl, backlog, ec);
     }
 
+    template<typename SettableSocketOption>
+    boost::system::error_code
+      set_option(implementation_type& impl, const SettableSocketOption& option
+                , boost::system::error_code& ec)
+    {
+      return service_impl_.set_option(impl, option, ec);
+    }
+
     int accept(implementation_type& impl, accept_handler_type handler
             , endpoint_type * ep, boost::system::error_code& ec)
     {

--- a/boost/cgi/impl/fcgi_request_service.ipp
+++ b/boost/cgi/impl/fcgi_request_service.ipp
@@ -605,6 +605,8 @@ BOOST_CGI_NAMESPACE_BEGIN
         }
         else
         {
+            if (len < 4)
+                break;
             name_len = ((buf[0] & 0x7F) << 24)
                      +  (buf[1]         << 16)
                      +  (buf[2]         <<  8)
@@ -612,6 +614,8 @@ BOOST_CGI_NAMESPACE_BEGIN
             buf += 4;
             len -= 4;
         }
+        if (0 == len)
+            break;
 
         if (*buf >> 7 == 0)
         {
@@ -620,6 +624,8 @@ BOOST_CGI_NAMESPACE_BEGIN
         }
         else
         {
+            if (len < 4)
+                break;
             data_len = ((buf[0] & 0x7F) << 24)
                      +  (buf[1]         << 16)
                      +  (buf[2]         <<  8)
@@ -627,6 +633,9 @@ BOOST_CGI_NAMESPACE_BEGIN
             buf += 4;
             len -= 4;
         }
+        if (0 == len)
+            break;
+
         name.assign(reinterpret_cast<const char*>(buf), name_len);
         data.assign(reinterpret_cast<const char*>(buf)+name_len, data_len);
         buf += (name_len + data_len);

--- a/boost/cgi/impl/fcgi_request_service.ipp
+++ b/boost/cgi/impl/fcgi_request_service.ipp
@@ -501,7 +501,7 @@ BOOST_CGI_NAMESPACE_BEGIN
       {
         this->get_io_service().run_one();
         if (this->get_io_service().stopped())
-          ec = error::eof;
+          this->get_io_service().reset();
       }
       
       return ec;

--- a/boost/cgi/scgi/request_acceptor_service.hpp
+++ b/boost/cgi/scgi/request_acceptor_service.hpp
@@ -149,8 +149,6 @@ BOOST_CGI_NAMESPACE_BEGIN
        bind(implementation_type& impl, const Endpoint& endpoint
            , boost::system::error_code& ec)
      {
-       acceptor_service_.set_option(impl.acceptor_,
-           boost::asio::socket_base::reuse_address(true), ec);
        return acceptor_service_.bind(impl.acceptor_, endpoint, ec);
      }
 
@@ -168,6 +166,14 @@ BOOST_CGI_NAMESPACE_BEGIN
        listen(implementation_type& impl, int backlog, boost::system::error_code& ec)
      {
        return acceptor_service_.listen(impl.acceptor_, backlog, ec);
+     }
+
+     template<typename SettableSocketOption>
+     boost::system::error_code
+       set_option(implementation_type& impl, const SettableSocketOption& option
+                 , boost::system::error_code& ec)
+     {
+       return acceptor_service_.set_option(impl.acceptor_, option, ec);
      }
      
      void do_accept(implementation_type& impl

--- a/libs/cgi/example/fcgi/hello_world/main.cpp
+++ b/libs/cgi/example/fcgi/hello_world/main.cpp
@@ -58,7 +58,7 @@ int main()
   try
   {
     service s;        // This becomes useful with async operations.
-    acceptor a(s);
+    acceptor a(s, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), 9000));
 
     for (;;)
     {


### PR DESCRIPTION
All fcgi examples do not work for me (Fedora 23, x86_64). There are multiple reasons: see commit messages. Now hello_world example works fine (including high load tests). All other FCGI and SCGI examples must be updated too (using basic_request_acceptor() with endpoint argument).
