### PR TITLE
Compilation fixes for tests and examples

### DIFF
--- a/libs/cgi/test/run/cgi_simple_request.cpp
+++ b/libs/cgi/test/run/cgi_simple_request.cpp
@@ -11,7 +11,7 @@
 //
 
 #include "boost/cgi/cgi.hpp"
-//#define BOOST_TEST_MODULE cgi_request_test
+#define BOOST_TEST_MODULE cgi_request_test
 #include <boost/test/unit_test.hpp>
 
 #include "request_test_template.hpp"

--- a/libs/cgi/test/run/cgi_test.cpp
+++ b/libs/cgi/test/run/cgi_test.cpp
@@ -1,5 +1,7 @@
 // this is the test file with the main function
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 //#include <boost/test/included/prg_exec_monitor.hpp>

--- a/libs/cgi/test/run/hello_world.cpp
+++ b/libs/cgi/test/run/hello_world.cpp
@@ -6,7 +6,9 @@
 
 #define BOOST_TEST_MODULE hello_world_test
 //#include <boost/test/unit_test.hpp>
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
 // the following definition must be defined once per test project
 #define BOOST_TEST_MAIN
 // include Boost.Test

--- a/libs/cgi/test/run/map_test.cpp
+++ b/libs/cgi/test/run/map_test.cpp
@@ -2,7 +2,7 @@
 #include "boost/cgi/common/map.hpp"
 #include <iostream>
 
-//#define BOOST_TEST_MODULE value_test_suite
+#define BOOST_TEST_MODULE value_test_suite
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE( map_test )

--- a/libs/cgi/test/run/name_test.cpp
+++ b/libs/cgi/test/run/name_test.cpp
@@ -2,7 +2,7 @@
 #include "boost/cgi/common/name.hpp"
 #include <iostream>
 
-//#define BOOST_TEST_MODULE name_test_suite
+#define BOOST_TEST_MODULE name_test_suite
 #include <boost/test/unit_test.hpp>
 
 using boost::cgi::common::name;

--- a/libs/cgi/test/run/parse_options.cpp
+++ b/libs/cgi/test/run/parse_options.cpp
@@ -1,6 +1,6 @@
 
 #include "boost/cgi/common/parse_options.hpp"
-//#define BOOST_TEST_MODULE parse_options_test
+#define BOOST_TEST_MODULE parse_options_test
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE( test_parse_options )

--- a/libs/cgi/test/run/response.cpp
+++ b/libs/cgi/test/run/response.cpp
@@ -10,7 +10,7 @@
 // Test the cgi::response class works as advertised.
 //
 
-//#define BOOST_TEST_MODULE response_test
+#define BOOST_TEST_MODULE response_test
 #include <boost/test/unit_test.hpp>
 
 #include "boost/cgi/common/response.hpp"

--- a/libs/cgi/test/run/stdio_connection.cpp
+++ b/libs/cgi/test/run/stdio_connection.cpp
@@ -1,14 +1,13 @@
 #include <boost/system/error_code.hpp>
-#include "boost/cgi/buffer.hpp"
+#include "boost/cgi/import/buffer.hpp"
 #include "boost/cgi/connections/stdio.hpp"
 
 int main()
 {
-  boost::cgi::common::connections::stdio conn;
-
+  boost::cgi::connections::stdio conn;
   boost::system::error_code ec;
 
-  conn.write_some(cgi::buffer("Hello, world"), ec);
+  conn.write_some(boost::cgi::common::buffer("Hello, world"), ec);
 
   return 0;
 }


### PR DESCRIPTION
Some edits to re-instate compilable 'make test examples'
Somehow tests and examples were broken, fix these.
thanks,